### PR TITLE
Actualizando dependencias lanyu-commons

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ repositories {
 }
 
 dependencies {
-	api 'com.github.LanyuEStudio:lanyuCommon:v1.0.0'
+	api 'com.github.LanyuEStudio:lanyu-commons:v1.0.0'
 }
 
 task sourcesJar(type: Jar, dependsOn: classes) {


### PR DESCRIPTION
Aparentemente, gradle.build necesita actualizar la dependencia de lanyu-commons por un cambio en la denominación en jitpack, de lanyuCommon a lanyu-commons.